### PR TITLE
chore: optimize builds

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,15 +1,25 @@
-**/*
-!/FUNCTIONS.md
-!/RUNTIMES.md
-!/REACT_QUERY.md
-!/**/*.ts
-!/**/*.js
-!/**/*.mjs
-!/**/*.json
-!/**/*.map
+# Source files
+src/
+test/
+tests/
+__tests__/
+*.test.ts
+*.spec.ts
 
-/eslint.config.mjs
-/cjs
-/.tshy
-/.tshy-*
-/__tests__
+# Build artifacts
+dist/node_modules/
+dist/**/*.map
+dist/**/*.test.js
+dist/**/*.spec.js
+
+# Development files
+.git/
+.github/
+.vscode/
+*.log
+.eslintrc*
+.prettierrc*
+tsconfig.json
+tshy.config.js
+vitest.config.ts
+.speakeasy/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atoma-sdk",
-  "version": "0.0.2",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atoma-sdk",
-      "version": "0.0.2",
+      "version": "0.2.1",
       "dependencies": {
         "@noble/curves": "^1.9.1",
         "@stablelib/blake2b": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atoma-sdk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "Speakeasy",
   "type": "module",
   "bin": {

--- a/tshy.config.js
+++ b/tshy.config.js
@@ -1,8 +1,8 @@
 export default {
   build: {
     outDir: "dist",
-    format: ["esm", "commonjs"],
-    sourcemap: true,
+    format: ["esm"],
+    sourcemap: false,
     declaration: true,
   },
   sourceDialects: ["atoma-sdk/source"],


### PR DESCRIPTION
The distributed package size on npm is currently 7.12 Mb, this is huge. Part of the reason is we are building BOTH CommonJS and ESM. 

These changes optimize to only build for ESM since it's more modern, standardized and smaller